### PR TITLE
move admin password indicator file to /etc/couchdb/ 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /var/run/couchdb
-RUN sed -i -r 's/;bind_address = 127.0.0.1/bind_address = 0.0.0.0/' /etc/couchdb/local.ini
+RUN sed -e 's/^bind_address = .*$/bind_address = 0.0.0.0/' -i /etc/couchdb/default.ini
 
 ADD create_couchdb_admin_user.sh /create_couchdb_admin_user.sh
 ADD run.sh /run.sh

--- a/create_couchdb_admin_user.sh
+++ b/create_couchdb_admin_user.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -f /var/lib/couchdb/.couchdb_admin_created ]; then
+if [ -f /etc/couchdb/.couchdb_admin_created ]; then
     echo "CouchDB 'admin' user already created!"
     exit 0
 fi
@@ -20,7 +20,7 @@ done
 echo "=> Creating an admin user with a ${_word} password in CouchDB"
 curl -s -X PUT http://127.0.0.1:5984/_config/admins/admin -d '"'${PASS}'"'
 echo "=> Done!"  
-touch /var/lib/couchdb/.couchdb_admin_created
+touch /etc/couchdb/.couchdb_admin_created
     
 echo "========================================================================"
 echo "You can now connect to this CouchDB server using:"

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,8 @@
 set -m
 
 #run CouchDB in background
-couchdb &
+# couchdb &
+/usr/bin/couchdb -a /etc/couchdb/default.ini -a /etc/couchdb/local.ini -b -r 5 -p /var/run/couchdb/couchdb.pid -o /dev/null -e /dev/null -R &
 
 #set password for admin account
 if [ ! -f /etc/couchdb/.couchdb_admin_created ]; then

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ set -m
 couchdb &
 
 #set password for admin account
-if [ ! -f /var/lib/couchdb/.couchdb_admin_created ]; then
+if [ ! -f /etc/couchdb/.couchdb_admin_created ]; then
 	/create_couchdb_admin_user.sh
 fi
 


### PR DESCRIPTION
as the admin password is stored there

If volume is used for /var/lib/couchdb/ to save data on host, 
and you start the container a second time,
the admin password in /etc/couchdb/local.ini is not persisted,
and not created again.

--> Keep the indicator file .couchdb_admin_created in same folder as local.ini file.
